### PR TITLE
Add packageManager key to package.json and include .yarn in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -27,3 +27,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+/.yarn
+

--- a/package.json
+++ b/package.json
@@ -115,5 +115,6 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Inclusion of yarn directory in ignore file is to resolve https://github.com/yarnpkg/yarn/issues/9065#issuecomment-2132395877

The packageManager change will hopefully prevent yarn and/or corepack from adding conflicting checksums in package.json for that key during builds